### PR TITLE
We have to set `base` in .vitepress/config.ts

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,7 @@ const MANUAL = {
 export default {
   title: "Pera",
   description: "Running frontend code with only a single .tsx file",
+  base: "/pera/",
   ignoreDeadLinks: [
     /^https?:\/\/localhost/,
   ],
@@ -22,6 +23,9 @@ export default {
     ],
     sidebar: [
       MANUAL,
+    ],
+    socialLinks: [
+      { icon: "github", link: "https://github.com/d2verb/pera" },
     ],
   },
 };


### PR DESCRIPTION
see: https://vitepress.dev/reference/site-config#base

> The base URL the site will be deployed at. You will need to set this if you plan to deploy your site under a sub path, for example, GitHub pages.